### PR TITLE
Add Cal Raleigh season tracker

### DIFF
--- a/cal.html
+++ b/cal.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Cal Raleigh Season Tracker</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap">
+  <style>
+    body {
+      margin: 0;
+      font-family: 'Open Sans', sans-serif;
+      background: #f6f8fa;
+      color: #24292f;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+    header, footer {
+      background: #24292f;
+      color: #fff;
+      text-align: center;
+      padding: 1rem 0;
+    }
+    main {
+      flex: 1;
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 2rem;
+    }
+    h1 {
+      margin: 0 0 1rem;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 2rem;
+    }
+    th, td {
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid #ddd;
+      text-align: right;
+    }
+    th {
+      text-align: left;
+      background: #eaecef;
+    }
+    canvas {
+      max-width: 100%;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Cal Raleigh Season Tracker</h1>
+  </header>
+  <main>
+    <section id="stats">
+      <table>
+        <thead>
+          <tr>
+            <th>Stat</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>Games</td><td id="games">--</td></tr>
+          <tr><td>At Bats</td><td id="atbats">--</td></tr>
+          <tr><td>Hits</td><td id="hits">--</td></tr>
+          <tr><td>Home Runs</td><td id="hr">--</td></tr>
+          <tr><td>RBI</td><td id="rbi">--</td></tr>
+          <tr><td>AVG</td><td id="avg">--</td></tr>
+          <tr><td>OBP</td><td id="obp">--</td></tr>
+          <tr><td>SLG</td><td id="slg">--</td></tr>
+          <tr><td>OPS</td><td id="ops">--</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section>
+      <canvas id="hrChart" height="200"></canvas>
+    </section>
+  </main>
+  <footer>
+    &copy; 2025 choggers.com
+  </footer>
+  <script src="js/chart.min.js"></script>
+  <script src="js/cal-tracker.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
   <main>
     <p>Welcome to the new choggers.com.</p>
     <p>This site is being rebuilt from scratch. Check back soon!</p>
+    <p><a href="cal.html">Cal Raleigh Season Tracker</a></p>
   </main>
   <footer>
     &copy; 2025 choggers.com

--- a/js/cal-tracker.js
+++ b/js/cal-tracker.js
@@ -1,0 +1,65 @@
+async function fetchJSON(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to fetch ' + url);
+  return res.json();
+}
+
+function currentYear() {
+  return new Date().getFullYear();
+}
+
+async function loadSeasonStats() {
+  const year = currentYear();
+  const data = await fetchJSON(`https://statsapi.mlb.com/api/v1/people/663728/stats?stats=season&season=${year}&group=hitting`);
+  const stat = data.stats?.[0]?.splits?.[0]?.stat || {};
+  const el = id => document.getElementById(id);
+  el('games').textContent = stat.gamesPlayed ?? '--';
+  el('atbats').textContent = stat.atBats ?? '--';
+  el('hits').textContent = stat.hits ?? '--';
+  el('hr').textContent = stat.homeRuns ?? '--';
+  el('rbi').textContent = stat.rbi ?? '--';
+  el('avg').textContent = stat.avg ?? '--';
+  el('obp').textContent = stat.obp ?? '--';
+  el('slg').textContent = stat.slg ?? '--';
+  el('ops').textContent = stat.ops ?? '--';
+}
+
+async function loadHrChart() {
+  const year = currentYear();
+  const data = await fetchJSON(`https://statsapi.mlb.com/api/v1/people/663728/stats?stats=gameLog&season=${year}&group=hitting`);
+  const logs = data.stats?.[0]?.splits || [];
+  const labels = logs.map((l, i) => i + 1);
+  const totals = [];
+  let sum = 0;
+  for (const l of logs) {
+    sum += Number(l.stat.homeRuns);
+    totals.push(sum);
+  }
+  const ctx = document.getElementById('hrChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{
+        label: 'Cumulative HR',
+        data: totals,
+        borderColor: '#d9534f',
+        backgroundColor: 'rgba(217,83,79,0.2)',
+        fill: false,
+        lineTension: 0.1
+      }]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        x: { display: true, title: { display: true, text: 'Game' } },
+        y: { display: true, title: { display: true, text: 'Home Runs' }, beginAtZero: true }
+      }
+    }
+  });
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  loadSeasonStats();
+  loadHrChart();
+});


### PR DESCRIPTION
## Summary
- add link on homepage to new tracker page
- create `cal.html` with modern style and season stats table
- implement `cal-tracker.js` to pull data from the MLB API and draw a chart of cumulative home runs

## Testing
- `bash fetch_logs.sh`

------
https://chatgpt.com/codex/tasks/task_e_687560fbf34c8326b331e79862ae6f97