### PR TITLE
Fix base path for custom domain

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -7,7 +7,7 @@ This project is configured to deploy to GitHub Pages using the `gh-pages` packag
 ### Prerequisites
 
 1. Ensure you have a GitHub repository set up
-2. Make sure the repository name matches the `base` path in `vite.config.js` (currently `/choggers.com/`)
+2. Make sure the repository name matches the `base` path in `vite.config.js` (set to `/` when using a custom domain)
 
 ### Deployment Steps
 
@@ -46,5 +46,5 @@ This project is configured to deploy to GitHub Pages using the `gh-pages` packag
 If you have a custom domain:
 
 1. Add a `CNAME` file to the `public` directory with your domain
-2. Update the `base` path in `vite.config.js` to `/` instead of `/choggers.com/`
+2. Ensure the `base` path in `vite.config.js` is set to `/`
 3. Configure your domain in GitHub Pages settings 

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+www.choggers.com

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/choggers.com/', // This matches your GitHub Pages repository name
+  // Use root base path for custom domain deployments
+  base: '/',
   build: {
     outDir: 'dist',
     assetsDir: 'assets',


### PR DESCRIPTION
## Summary
- set `base` in Vite config to root for custom domain usage
- copy `CNAME` into `public` so it is deployed with the site
- document custom domain base path in `DEPLOYMENT.md`

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878380b64988326b531bc46d11451b7