### PR TITLE
Improve mobile usability of bullpen overview

### DIFF
--- a/src/components/BullpenOverviewSection.css
+++ b/src/components/BullpenOverviewSection.css
@@ -82,6 +82,7 @@
 
 .table-container {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   margin-bottom: 30px;
 }
 
@@ -90,6 +91,7 @@
   border-collapse: collapse;
   font-family: 'Roboto Mono', monospace;
   font-size: 12px;
+  min-width: 600px;
 }
 
 .bullpen-table th,
@@ -136,6 +138,7 @@
 
 .outings-table-container {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .outings-table {
@@ -143,6 +146,7 @@
   border-collapse: collapse;
   font-family: 'Roboto Mono', monospace;
   font-size: 11px;
+  min-width: 700px;
 }
 
 .outings-table th,
@@ -259,6 +263,7 @@
   .bullpen-table,
   .outings-table {
     font-size: 10px;
+    min-width: 550px;
   }
   
   .bullpen-table th,
@@ -280,6 +285,7 @@
   .bullpen-table,
   .outings-table {
     font-size: 9px;
+    min-width: 500px;
   }
   
   .pitcher-name {

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -11,6 +11,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  width: 100%;
   max-width: 1200px;
   margin: auto;
   gap: 20px;

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,7 @@ body {
   font-family: 'Roboto Mono', monospace;
   min-height: 100vh;
   line-height: 1.6;
+  overflow-x: hidden;
 }
 
 #root {


### PR DESCRIPTION
## Summary
- adjust bullpen tables to scroll on small screens
- let header content stretch to device width
- prevent horizontal body overflow

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687de2c1379483269cb997699941fc62